### PR TITLE
Lazy loading of variables from Ansible's HostVars object

### DIFF
--- a/src/ansiblecmdb/ansible_cmdb.py
+++ b/src/ansiblecmdb/ansible_cmdb.py
@@ -285,7 +285,8 @@ class Ansible(object):
             break
 
         for fname in flist:
-            if fname.startswith('.'):
+            # Skip hidden files and inventory cache(s)
+            if fname.startswith('.') or fname.startswith('ansible_inventory_'):
                 continue
             self.log.debug("Reading host facts from {0}".format(os.path.join(fact_dir, fname)))
             hostname = fname

--- a/src/ansiblecmdb/ansible_via_api.py
+++ b/src/ansiblecmdb/ansible_via_api.py
@@ -32,10 +32,10 @@ class AnsibleViaAPI(Ansible):
         # we do the simplest thing that can work.
         if self.limit:
             inventory.subset(self.limit)
-            limited_hosts = inventory.get_hosts()
-            for h in self.hosts.keys():
-                if h not in limited_hosts:
-                    del self.hosts[h]
+
+        # Discard facts from hosts not in the inventory from the result set
+        for host in set(self.hosts.keys()).difference(set(inventory.hosts.keys())):
+            self.hosts.pop(host)
 
         for host in inventory.get_hosts():
 

--- a/test/f_inventory/dyninv.py
+++ b/test/f_inventory/dyninv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 

--- a/test/f_inventory/mixeddir/dyninv.py
+++ b/test/f_inventory/mixeddir/dyninv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 


### PR DESCRIPTION
This takes advantage of lazy loading host variables from inventory so that
only variables whose values are accessed by the template are actually loaded AND
they go through the Jinja templater when they are loaded.

Allows for correct representation of things like:
```
cat inventory/group_vars/mgmt_network.yml
ipv4:
- '{{ip_address_mgmt}}'
```